### PR TITLE
feat: use new terminology for synchronization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,13 @@ export {
 } from './set'
 export {
   type SynchronizationRequest,
-  type SynchronizationResponse,
-  type SynchronizationResponseIncomplete,
-  type SynchronizationResponseSuccess,
+
+  type SynchronizationResult,
+  type SynchronizationResultIncomplete,
+  type SynchronizationResultComplete,
+
+  // For backwards compatibility.
+  type SynchronizationResult as SynchronizationResponse,
+  type SynchronizationResultIncomplete as SynchronizationResponseIncomplete,
+  type SynchronizationResultComplete as SynchronizationResponseSuccess,
 } from './sync'

--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -27,7 +27,7 @@ describe(processSetSynchronization.name, () => {
   })
 
   it('returns null on succeess', () => {
-    const request = processSetSynchronization(sync, {type: 'success'})
+    const request = processSetSynchronization(sync, {type: 'complete'})
     expect(request).toBeNull()
   })
 

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,6 +1,6 @@
 import {type EncodableObject, encode, type Encoded, type ID} from './encoder'
 import {SetSketch} from './reconciler'
-import type {SynchronizationRequest, SynchronizationResponse} from './sync'
+import type {SynchronizationRequest, SynchronizationResult} from './sync'
 
 /**
  * A set descriptor. This follows the very specific form with a property called
@@ -93,29 +93,29 @@ export class SetBuilder {
 /**
  * The main logic for synchronizing a set to a server.
  *
- * Initially this function should be invoked with `prevResponse` set to `null`.
+ * Initially this function should be invoked with `prevResult` set to `null`.
  * This returns a SynchronizationRequest which should then be sent to a server.
- * Once the server returns a response this function should be invoked with this
+ * Once the server returns a result this function should be invoked with this
  * as a parameter. This proccess should be continued until this function return
  * `null`.
  *
  * @param sync The set to synchronize.
- * @param prevResponse The response from the previous request.
+ * @param prevResult The result from the previous synchronization.
  * @returns `null` when the synchronization is complete, or a request which should be sent.
  * @public
  */
 export function processSetSynchronization<Type extends string>(
   sync: SetSynchronization<Type>,
-  prevResponse: SynchronizationResponse | null,
+  prevResult: SynchronizationResult | null,
 ): SynchronizationRequest | null {
   const id = sync.set.id
-  if (!prevResponse) return {id}
+  if (!prevResult) return {id}
 
-  if (prevResponse.type === 'success') return null
+  if (prevResult.type === 'complete') return null
 
   const descriptors: Array<Encoded<string, EncodableObject>> = []
 
-  for (const missingId of prevResponse.missingIds) {
+  for (const missingId of prevResult.missingIds) {
     const descriptor = findDescriptor(sync, missingId)
     if (!descriptor) throw new Error(`Synchronization server is requested an unknonwn descriptor`)
     descriptors.push(descriptor)

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -13,22 +13,20 @@ export type SynchronizationRequest = {
 }
 
 /**
- * The response from a server which supports descriptor synchronization.
+ * The result from a server which supports descriptor synchronization.
  *
  * @public
  */
-export type SynchronizationResponse =
-  | SynchronizationResponseSuccess
-  | SynchronizationResponseIncomplete
+export type SynchronizationResult = SynchronizationResultComplete | SynchronizationResultIncomplete
 
 /**
- * SynchronizationResponseSuccess is returned from a synchronization server when
- * the requested descriptor has been successfully synchronized.
+ * SynchronizationResultComplete is returned from a synchronization server when
+ * the requested descriptor has been completely synchronized.
  *
  * @public
  */
-export type SynchronizationResponseSuccess = {
-  type: 'success'
+export type SynchronizationResultComplete = {
+  type: 'complete'
 }
 
 /**
@@ -37,7 +35,7 @@ export type SynchronizationResponseSuccess = {
  *
  * @public
  */
-export type SynchronizationResponseIncomplete = {
+export type SynchronizationResultIncomplete = {
   type: 'incomplete'
 
   /**


### PR DESCRIPTION
- "result" instead of "response"
- "type: complete" instead of "type: success".  This is not considered a breaking change since you're supposed to just pass the response/request back and forth from the server.