### PR TITLE
chore: build project before it's being published

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "pkg build --strict --clean --check",
     "format": "prettier --write --cache --ignore-unknown .",
     "lint": "eslint . --ext .cjs,.js,.ts,.tsx",
+    "prepublishOnly": "pkg build --strict --clean --check",
     "test": "vitest",
     "ts:check": "tsc --noEmit"
   },


### PR DESCRIPTION
Turns out that 1.1.0 released through GitHub Action wasn't built properly 🙃 